### PR TITLE
Fix for GopherJS HierarchyRequestError

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -59,7 +59,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			el.index = intAppend(currentParent.index, len(currentParent.children))
+			el.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
 			// Set this element's parent
 			el.parent = currentParent
 			// Add this element to the currentParent's children
@@ -131,7 +131,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			text.index = intAppend(currentParent.index, len(currentParent.children))
+			text.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
 			// Set this text node's parent
 			text.parent = currentParent
 			// Add this text node to the currentParent's children
@@ -152,7 +152,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			comment.index = intAppend(currentParent.index, len(currentParent.children))
+			comment.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
 			// Set this comment node's parent
 			comment.parent = currentParent
 			// Add this comment node to the currentParent's children
@@ -204,15 +204,4 @@ func wasAutoClosed(tree *Tree, tagName string) bool {
 	// The tag was autoclosed iff the last bytes to be read
 	// were not the closing tag.
 	return string(tree.reader.buf[start:stop]) != closingTag
-}
-
-// intAppend is a workaround for an apparent bug in GopherJS. Using just
-// append() works fine in regular Go, but in GopherJS it lead to some
-// index slices being modified when they shouldn't. Copying the parent's
-// index explicitly into a new slice seems to fix that issue.
-func intAppend(parentIndex []int, newValue int) []int {
-	index := make([]int, len(parentIndex)+1)
-	copy(index, parentIndex)
-	index[len(index)-1] = newValue
-	return index
 }

--- a/parse.go
+++ b/parse.go
@@ -59,7 +59,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			el.index = append(currentParent.index, len(currentParent.children))
+			el.index = intAppend(currentParent.index, len(currentParent.children))
 			// Set this element's parent
 			el.parent = currentParent
 			// Add this element to the currentParent's children
@@ -131,7 +131,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			text.index = append(currentParent.index, len(currentParent.children))
+			text.index = intAppend(currentParent.index, len(currentParent.children))
 			// Set this text node's parent
 			text.parent = currentParent
 			// Add this text node to the currentParent's children
@@ -152,7 +152,7 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			comment.index = append(currentParent.index, len(currentParent.children))
+			comment.index = intAppend(currentParent.index, len(currentParent.children))
 			// Set this comment node's parent
 			comment.parent = currentParent
 			// Add this comment node to the currentParent's children
@@ -204,4 +204,15 @@ func wasAutoClosed(tree *Tree, tagName string) bool {
 	// The tag was autoclosed iff the last bytes to be read
 	// were not the closing tag.
 	return string(tree.reader.buf[start:stop]) != closingTag
+}
+
+// intAppend is a workaround for an apparent bug in GopherJS. Using just
+// append() works fine in regular Go, but in GopherJS it lead to some
+// index slices being modified when they shouldn't. Copying the parent's
+// index explicitly into a new slice seems to fix that issue.
+func intAppend(parentIndex []int, newValue int) []int {
+	index := make([]int, len(parentIndex)+1)
+	copy(index, parentIndex)
+	index[len(index)-1] = newValue
+	return index
 }

--- a/parse.go
+++ b/parse.go
@@ -59,7 +59,9 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			el.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
+			el.index = make([]int, len(currentParent.index)+1)
+			copy(el.index, currentParent.index)
+			el.index[len(currentParent.index)] = len(currentParent.children)
 			// Set this element's parent
 			el.parent = currentParent
 			// Add this element to the currentParent's children
@@ -131,7 +133,9 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			text.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
+			text.index = make([]int, len(currentParent.index)+1)
+			copy(text.index, currentParent.index)
+			text.index[len(currentParent.index)] = len(currentParent.children)
 			// Set this text node's parent
 			text.parent = currentParent
 			// Add this text node to the currentParent's children
@@ -152,7 +156,9 @@ func parseToken(tree *Tree, token xml.Token, currentParent *Element) (nextParent
 		}
 		if currentParent != nil {
 			// Set the index based on how many children we've seen so far
-			comment.index = append(append([]int(nil), currentParent.index...), len(currentParent.children))
+			comment.index = make([]int, len(currentParent.index)+1)
+			copy(comment.index, currentParent.index)
+			comment.index[len(currentParent.index)] = len(currentParent.children)
 			// Set this comment node's parent
 			comment.parent = currentParent
 			// Add this comment node to the currentParent's children

--- a/patch.go
+++ b/patch.go
@@ -103,6 +103,22 @@ func (p *Remove) Patch(root dom.Element) error {
 	}
 	self := findInDOM(p.Node, root)
 	parent.RemoveChild(self)
+
+	// p.Node was removed, so subtract one from the final index for all
+	// siblings that come after it.
+	lastIndex := p.Node.Index()[len(p.Node.Index())-1]
+	for _, sibling := range p.Node.Parent().Children()[lastIndex:] {
+		switch t := sibling.(type) {
+		case *Element:
+			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+		case *Text:
+			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+		case *Comment:
+			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+		default:
+			panic("unreachable")
+		}
+	}
 	return nil
 }
 

--- a/patch.go
+++ b/patch.go
@@ -106,19 +106,22 @@ func (p *Remove) Patch(root dom.Element) error {
 
 	// p.Node was removed, so subtract one from the final index for all
 	// siblings that come after it.
-	lastIndex := p.Node.Index()[len(p.Node.Index())-1]
-	for _, sibling := range p.Node.Parent().Children()[lastIndex:] {
-		switch t := sibling.(type) {
-		case *Element:
-			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
-		case *Text:
-			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
-		case *Comment:
-			t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
-		default:
-			panic("unreachable")
+	if p.Node.Parent() != nil {
+		lastIndex := p.Node.Index()[len(p.Node.Index())-1]
+		for _, sibling := range p.Node.Parent().Children()[lastIndex:] {
+			switch t := sibling.(type) {
+			case *Element:
+				t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+			case *Text:
+				t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+			case *Comment:
+				t.index[len(t.index)-1] = t.index[len(t.index)-1] - 1
+			default:
+				panic("unreachable")
+			}
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes two things:

1) Related to https://github.com/albrow/vdom/issues/1, it appears that there's a bug in GopherJS with `append()` that sometimes causes the slice used as the first parameter to be modified when it's not supposed to be; the HierarchyRequestError was caused by the final index of an element being modified after it had been calculated. My workaround is to replace these uses of `append()` with a method that explicitly creates a new slice, copies the old one into it, and then sets the final value.

2) Fixing the HierarchyRequestError revealed a bug in the implementation of `Remove.Patch()`: the act of removing an element from the DOM invalidates the final index value for all sibling nodes following it, so I quickly ran into a slice out-of-bounds error. I fixed this by iterating over the node's remaining siblings and updating each final index value appropriately.

---

As a side note, I ran into one more issue that occurs when the browser's DOM doesn't exactly match the HTML; for example, a `<table>` tag missing a `<tbody>` will have one quietly added, which means that a template like this won't work for complex patching:

```html
<table>
  <tr>...</tr>
</table>
```

But this one will:

```html
<table>
  <tbody>
    <tr>...</tr>
  </tbody>
</table>
```

I'm not sure what the fix for that one is, but it's easily avoided by ensuring all your HTML is well-formed and doesn't result in any implicit modifications by the browser.